### PR TITLE
When tray mode is active, only close the UI and not the entire application.

### DIFF
--- a/Atomos.UI/Views/MainWindow.axaml.cs
+++ b/Atomos.UI/Views/MainWindow.axaml.cs
@@ -111,8 +111,15 @@ namespace Atomos.UI.Views
 
             this.Get<Button>("CloseButton").Click += (s, e) =>
             {
-                _logger.Info("Close button clicked");
-                Close();
+                if ((bool)_configuration.ReturnConfigValue(x => x.UI.MinimiseToTray)) 
+                {
+                    HiddenWindows.HideMainWindow();
+                    _logger.Info("Close button clicked, but minimizing to tray is enabled. Use tray to fully close application.");
+                } else 
+                {
+                    Close();
+                    _logger.Info("Close button clicked");
+                }
             };
         }
 


### PR DESCRIPTION
This change brings Atomos in line with behavior of other tray applications while minimize to tray is active.

While minimize to tray is active, the application is only closed when the tray icon is closed. Remaining in line with the behavior of other tray applications reduces user confusion and incorporates the users expected muscle memory of tray application behavior. 